### PR TITLE
added links to docs/examples.rst

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -5,7 +5,7 @@ Examples
 3D-point cloud
 ~~~~~~~~~~~~~~
 
-Check the ``examples`` directory for more.
+Check the `examples <https://github.com/scikit-tda/kepler-mapper/tree/master/examples/>`_ directory for more.
 
 .. figure:: http://i.imgur.com/OQqHt9R.png
    :alt: Click for large
@@ -14,7 +14,8 @@ Check the ``examples`` directory for more.
 Very noisy datasets
 ~~~~~~~~~~~~~~~~~~~
 
-Check the ``examples\makecircles`` directory for code
+Check the `examples\\makecircles <https://github.com/scikit-tda/kepler-mapper/tree/master/examples/makecircles
+/>`_ directory for code
 
 .. figure:: http://i.imgur.com/OmETfe5.png
    :alt: Click for large
@@ -33,7 +34,7 @@ Unsupervised Anomaly Detection
 
 Isolation Forest and L^2-Norm lens on Winsconsin Breast Cancer Data.
 
-Check the ``examples\breast-cancer`` directory for code
+Check the `examples\\breast-cancer <https://github.com/scikit-tda/kepler-mapper/tree/master/examples/breast-cancer/>`_ directory for code
 
 .. figure:: http://i.imgur.com/ewjRodK.png
    :alt: Click for large


### PR DESCRIPTION
## Issue + Fix

Some of the descriptions say "check the `example/dir` directory for code." Why not just link to the directory? 🙂 

I noticed it when I was going through the website today. 

Nice work, btw! 👍

## Things to note:

- 🔗 it links directly to the github rep, since these examples code doesn't live anywhere in the docs. If those change, then these links will break
- 🙃 I didn't build the website after the change since; I figured y'all will be making changes soon anyway
- 🍔 it breaks the `preformatted styling`... I haven't used .rst before, and I had to run to dinner, so I just went with this

Let me know if you have questions, or if this isn't what you're looking for