### PR TITLE
Custom color functions

### DIFF
--- a/kmapper/kmapper.py
+++ b/kmapper/kmapper.py
@@ -23,7 +23,8 @@ from .visuals import (
     format_mapper_data,
     build_histogram,
     colorscale_default,
-    render_template,
+    _default_row_color_function,
+    _default_node_color_function,
 )
 
 __all__ = [
@@ -621,8 +622,8 @@ class KeplerMapper(object):
         self,
         graph,
         color_data=None,
-        row_color_function=lambda color_data, member_ids: np.mean(color_data[member_ids], axis=1),
-        node_color_function=np.mean,
+        row_color_function=_default_row_color_function,
+        node_color_function=_default_node_color_function,
         custom_tooltips=None,
         custom_meta=None,
         path_html="mapper_visualization_output.html",

--- a/kmapper/visuals.py
+++ b/kmapper/visuals.py
@@ -142,7 +142,7 @@ def init_color_data(graph, color_data=None):
     return color_data
 
 
-def format_meta(graph, custom_meta=None, color_function_name=None):
+def format_meta(graph, custom_meta=None, color_data_name=None):
     n = [l for l in graph["nodes"].values()]
     n_unique = len(set([i for s in n for i in s]))
 
@@ -157,8 +157,8 @@ def format_meta(graph, custom_meta=None, color_function_name=None):
             projection = custom_meta["projection"]
             custom_meta["projection"] = _to_html_format(projection)
 
-        if color_function_name is not None:
-            custom_meta["color_function"] = color_function_name
+        if color_data_name is not None:
+            custom_meta["color_data"] = color_data_name
 
     mapper_summary = {
         "custom_meta": custom_meta,
@@ -172,8 +172,17 @@ def format_meta(graph, custom_meta=None, color_function_name=None):
 
 
 def format_mapper_data(
-
-    graph, color_data, row_color_function, node_color_function, X, X_names, lens, lens_names, custom_tooltips, env, nbins=10
+    graph,
+    color_data,
+    row_color_function,
+    node_color_function,
+    X,
+    X_names,
+    lens,
+    lens_names,
+    custom_tooltips,
+    env,
+    nbins=10,
 ):
     json_dict = {"nodes": [], "links": []}
     node_id_to_num = {}
@@ -418,3 +427,12 @@ def _type_node():
 
 def _size_link_width(graph, node_id, linked_node_id):
     return 1
+
+def _default_row_color_function(color_data, member_ids):
+    if color_data.ndim == 1:
+        return color_data[member_ids]
+    else:
+        return np.mean(color_data[member_ids], axis=1)
+
+def _default_node_color_function(member_colors):
+    return np.mean(member_colors)


### PR DESCRIPTION
Phew, this was dizzying. And of course I don't have new tests! But the old ones pass...

* `color_function` is renamed to `color_data`
* `color_data` may be whatever -- 1d or 2d. Multidimensional is useful for me because my color data is a square distance matrix, and I want row_color and node_color to be dependent on only the other rows within a given node
* options to specify a `row_color_function` and a `node_color_function` added. 
    * `row_color_function` is passed `color_data` and node `member_ids`. The default is to just average along axis=1 if not 1d, or to just return `color_data[member_ids]` if 1d.
    * `node_color_function` is passed `member_colors` as returned by `row_color_function`. The default is `np.mean`, but now anything is possible!

Additionally,
* the call to `graph_data_distribution` has been removed. It was only used to calculate node colors, which were then passed to `build_histogram`. But the node_colors are already available in the output of `format_mapper_data`, so I switched it to extract them from there.
* I calculated the member_colors once in the top of the loop over nodes, and passed around those member_colors instead of repeatedly recalculating them in tooltip component building
* I started to look at refactoring _format_cluster_statistics, but my head exploded. It looks like those functions assume that X is a set of coordinate points, a la the horse vis stuff. Then I saw all of the TODOS and ran away. Another PR for another day.
* I updated plotlyviz.py as best as I could. Tests are passing but I am not well versed in plotly.

My other PR, #149, can be rebased pretty easily onto this if it is merged, or the other way around.