### PR TITLE
added a sparse-compatible ID column prefixing

### DIFF
--- a/kmapper/kmapper.py
+++ b/kmapper/kmapper.py
@@ -13,7 +13,7 @@ import numpy as np
 from sklearn import cluster, preprocessing, manifold, decomposition
 from sklearn.model_selection import StratifiedKFold, KFold
 from scipy.spatial import distance
-from scipy.sparse import issparse
+from scipy.sparse import issparse, hstack
 
 from .cover import Cover
 from .nerve import GraphNerve
@@ -25,7 +25,6 @@ from .visuals import (
     graph_data_distribution,
     colorscale_default,
 )
-from scipy.sparse import hstack, csr
 
 __all__ = [
     "KeplerMapper", 
@@ -381,7 +380,7 @@ class KeplerMapper(object):
             Lower dimensional representation of data. In general will be output of `fit_transform`.
 
         X: Numpy Array
-            Original data or data to run clustering on. If `None`, then use `lens` as default.
+            Original data or data to run clustering on. If `None`, then use `lens` as default. X can be a SciPy sparse matrix.
 
         clusterer: Default: DBSCAN
             Scikit-learn API compatible clustering algorithm. Must provide `fit` and `predict`.
@@ -499,7 +498,7 @@ class KeplerMapper(object):
         # Prefix'ing the data with an ID column
         ids = np.array([x for x in range(lens.shape[0])])
         lens = np.c_[ids, lens]
-        if type(X) == csr.csr_matrix:
+        if issparse(X):
             X = hstack([ids[np.newaxis].T, X], format='csr')
         else:
             X = np.c_[ids, X]

--- a/kmapper/kmapper.py
+++ b/kmapper/kmapper.py
@@ -25,6 +25,7 @@ from .visuals import (
     graph_data_distribution,
     colorscale_default,
 )
+from scipy.sparse import hstack, csr
 
 __all__ = [
     "KeplerMapper", 
@@ -498,7 +499,10 @@ class KeplerMapper(object):
         # Prefix'ing the data with an ID column
         ids = np.array([x for x in range(lens.shape[0])])
         lens = np.c_[ids, lens]
-        X = np.c_[ids, X]
+        if type(X) == csr.csr_matrix:
+            X = hstack([ids[np.newaxis].T, X], format='csr')
+        else:
+            X = np.c_[ids, X]
 
         # Cover scheme defines a list of elements
         bins = self.cover.fit(lens)

--- a/test/test_mapper.py
+++ b/test/test_mapper.py
@@ -408,3 +408,11 @@ class TestLens:
         np.testing.assert_array_equal(lens_10, lens_11)
         assert not np.array_equal(lens_10, lens_2)
         assert not np.array_equal(lens_10, lens_1)
+
+    def test_map_sparse(self):
+        mapper = KeplerMapper()
+
+        data = sparse.random(100, 10)
+        lens = mapper.fit_transform(data)
+        mapping = mapper.map(lens, data)
+

--- a/test/test_mapper.py
+++ b/test/test_mapper.py
@@ -412,7 +412,7 @@ class TestLens:
     def test_map_sparse(self):
         mapper = KeplerMapper()
 
-        data = sparse.random(100, 10)
+        data = sparse.random(100, 10, random_state=100101)
         lens = mapper.fit_transform(data)
         mapping = mapper.map(lens, data)
 


### PR DESCRIPTION
As discussed in #162, here is how I made keppler-mapper sparse-compatible with my use case.