### PR TITLE
add zenodo json file for easier github release webhook integration

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,30 @@
+{
+  "creators": [
+    {
+      "affiliation": "Nubank",
+      "name": "Hendrik Jacob van Veen"
+    },
+    {
+      "affiliation": "Department of Mathematics and Statistics, Washington State University Vancouver",
+      "name": "Nathaniel Saul",
+      "orcid": "0000-0002-8549-9810"
+    },
+    {
+      "affiliation": "Leeds School of Business, University of Colorado Boulder",
+      "name": "Sam W. Mangham",
+      "orcid": "0000-0001-7511-5652"
+    },
+    {
+      "affiliation": "Department of Electronics & Computer Science, University of Southampton, Southampton, SO17 1BJ, UK",
+      "name": "Eargle, David",
+      "orcid": "0000-0002-4056-8114"
+    }
+  ],
+  "keywords": [
+    "Python",
+    "Mapper",
+    "Topological Data Analysis"
+  ],
+  "license": "mit-license",
+  "upload_type": "software"
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -5,7 +5,7 @@
       "name": "Hendrik Jacob van Veen"
     },
     {
-      "affiliation": "Department of Mathematics and Statistics, Washington State University Vancouver",
+      "affiliation": "New Relic",
       "name": "Nathaniel Saul",
       "orcid": "0000-0002-8549-9810"
     },


### PR DESCRIPTION
This file will give a nice starting point for releases auto-published to zenodo through the github release webhook. I specified the same author info (order, ORCIDs and affiliations) and keywords as in paper.md, and I specified the MIT license from the LICENSE file. 

By default, zenodo reads repo api metadata for the above info, but it can be pretty wrong, as is the current case with kepler-mapper releases on zenodo where it is listed that pep8speaks is a coauthor (lol).

All of this metadata can be edited after the record and DOI are created on zenodo via the github release webhook. So, with this json file in place, it will be easier to prep the zenodo release for JOSS.

I validated the .zenodo.json file using a test repo. Unfortunately, there is no validation method for the .zenodo.json file besides trial and error. See https://github.com/deargle/zenodo-test and the associated release https://zenodo.org/record/3460114 to confirm.