### PR TITLE
Enable using precomputed distance matrices for clustering.

### DIFF
--- a/kmapper/kmapper.py
+++ b/kmapper/kmapper.py
@@ -500,17 +500,19 @@ class KeplerMapper(object):
         # we consider clustering or skipping it.
         cluster_params = clusterer.get_params()
 
-        min_cluster_samples = cluster_params.get(
-            "n_clusters",
-            cluster_params.get(
-                "min_cluster_size", cluster_params.get("min_samples", 1)
-            ),
-        )
+        if precomputed:
+            min_cluster_samples = 2
+        else:
+            min_cluster_samples = cluster_params.get(
+                "n_clusters",
+                cluster_params.get(
+                    "min_cluster_size", cluster_params.get("min_samples", 1)
+                ),
+            )
 
         if self.verbose > 1:
             print(
-                "Minimal points in hypercube before clustering: %d"
-                % (min_cluster_samples)
+                "Minimal points in hypercube before clustering: {}".format(min_cluster_samples)
             )
 
         # Subdivide the projected data X in intervals/hypercubes with overlap


### PR DESCRIPTION
The purpose of this PR is to add a minor rewrite of minimal cluster sampling in order to allow precomputed distance matrices. This fixes crash when using clustering distance treshold, which is without a fixed number of clusters.

Also a minor rewrite of the print statement. By not specifying type of `min_cluster_samples` it will not crash if a float is passed.