### PR TITLE
allow custom colorscale in KepplerMapper.visualize

### DIFF
--- a/kmapper/kmapper.py
+++ b/kmapper/kmapper.py
@@ -27,7 +27,7 @@ from .visuals import (
 )
 
 __all__ = [
-    "KeplerMapper", 
+    "KeplerMapper",
     "cluster" #expose this to make examples and usage tidier
 ]
 
@@ -35,19 +35,19 @@ __all__ = [
 class KeplerMapper(object):
     """With this class you can build topological networks from (high-dimensional) data.
 
-    1)   	Fit a projection/lens/function to a dataset and transform it.
+    1)          Fit a projection/lens/function to a dataset and transform it.
                 For instance "mean_of_row(x) for x in X"
-    2)   	Map this projection with overlapping intervals/hypercubes.
+    2)          Map this projection with overlapping intervals/hypercubes.
                 Cluster the points inside the interval
                 (Note: we cluster on the inverse image/original data to lessen projection loss).
                 If two clusters/nodes have the same members (due to the overlap), then:
                 connect these with an edge.
-    3)  	Visualize the network using HTML and D3.js.
+    3)          Visualize the network using HTML and D3.js.
 
     KM has a number of nice features, some which get forgotten.
         - ``project``: Some projections it makes sense to use a distance matrix, such as knn_distance_#. Using ``distance_matrix = <metric>`` for a custom metric.
-        - ``fit_transform``: Applies a sequence of projections. Currently, this API is a little confusing and might be changed in the future. 
-    
+        - ``fit_transform``: Applies a sequence of projections. Currently, this API is a little confusing and might be changed in the future.
+
 
 
     """
@@ -60,7 +60,7 @@ class KeplerMapper(object):
 
         verbose: int, default is 0
             Logging level. Currently 3 levels (0,1,2) are supported. For no logging, set `verbose=0`. For some logging, set `verbose=1`. For complete logging, set `verbose=2`.
-            
+
         """
 
         # TODO: move as many of the arguments from fit_transform and map into here.
@@ -97,7 +97,7 @@ class KeplerMapper(object):
             Scaler of the data applied after mapping. Use None for no scaling. Default = preprocessing.MinMaxScaler() if None, do no scaling, else apply scaling to the projection. Default: Min-Max scaling
 
         distance_matrix : Either str or None
-            If not None, then any of ["braycurtis", "canberra", "chebyshev", "cityblock", "correlation", "cosine", "dice", "euclidean", "hamming", "jaccard", "kulsinski", "mahalanobis", "matching", "minkowski", "rogerstanimoto", "russellrao", "seuclidean", "sokalmichener", "sokalsneath", "sqeuclidean", "yule"]. 
+            If not None, then any of ["braycurtis", "canberra", "chebyshev", "cityblock", "correlation", "cosine", "dice", "euclidean", "hamming", "jaccard", "kulsinski", "mahalanobis", "matching", "minkowski", "rogerstanimoto", "russellrao", "seuclidean", "sokalmichener", "sokalsneath", "sqeuclidean", "yule"].
             If False do nothing, else create a squared distance matrix with the chosen metric, before applying the projection.
 
         Returns
@@ -295,7 +295,7 @@ class KeplerMapper(object):
 
         Examples
         --------
-        >>> # Stack / chain projections. You could do this manually, 
+        >>> # Stack / chain projections. You could do this manually,
         >>> # or pipeline with `.fit_transform()`. Works the same as `.project()`,
         >>> # but accepts lists. f(raw text) -> f(tfidf) -> f(isomap 100d) -> f(umap 2d)
         >>> projected_X = mapper.fit_transform(
@@ -396,29 +396,29 @@ class KeplerMapper(object):
         precomputed : Boolean
             Tell Mapper whether the data that you are clustering on is a precomputed distance matrix. If set to
             `True`, the assumption is that you are also telling your `clusterer` that `metric='precomputed'` (which
-            is an argument for DBSCAN among others), which 
+            is an argument for DBSCAN among others), which
             will then cause the clusterer to expect a square distance matrix for each hypercube. `precomputed=True` will give a square matrix
             to the clusterer to fit on for each hypercube.
-            
+
         remove_duplicate_nodes: Boolean
             Removes duplicate nodes before edges are determined. A node is considered to be duplicate
             if it has exactly the same set of points as another node.
 
         nr_cubes: Int
-            
+
             .. deprecated:: 1.1.6
 
                 define Cover explicitly in future versions
 
             The number of intervals/hypercubes to create. Default = 10.
-            
+
         overlap_perc: Float
             .. deprecated:: 1.1.6
 
-                define Cover explicitly in future versions    
+                define Cover explicitly in future versions
 
-            The percentage of overlap "between" the intervals/hypercubes. Default = 0.1. 
-            
+            The percentage of overlap "between" the intervals/hypercubes. Default = 0.1.
+
 
 
         Returns
@@ -436,10 +436,10 @@ class KeplerMapper(object):
         >>> graph = mapper.map(X_projected)
 
         >>> # Use 20 cubes/intervals per projection dimension, with a 50% overlap
-        >>> graph = mapper.map(X_projected, X_inverse, 
+        >>> graph = mapper.map(X_projected, X_inverse,
         >>>                    cover=kmapper.Cover(n_cubes=20, perc_overlap=0.5))
 
-        >>> # Use multiple different cubes/intervals per projection dimension, 
+        >>> # Use multiple different cubes/intervals per projection dimension,
         >>> # And vary the overlap
         >>> graph = mapper.map(X_projected, X_inverse,
         >>>                    cover=km.Cover(n_cubes=[10,20,5],
@@ -545,12 +545,12 @@ class KeplerMapper(object):
                             ).shape[0], i
                         )
                     )
-        
+
                 for pred in np.unique(cluster_predictions):
-                    # if not predicted as noise                       
-                    if pred != -1 and not np.isnan(pred):  
+                    # if not predicted as noise
+                    if pred != -1 and not np.isnan(pred):
                         cluster_id = "cube{}_cluster{}".format(i, int(pred))
-                        
+
                         nodes[cluster_id] = hypercube[:, 0][cluster_predictions == pred].astype(int).tolist()
             elif self.verbose > 1:
                 print("Cube_%s is empty.\n" % (i))
@@ -615,6 +615,7 @@ class KeplerMapper(object):
         self,
         graph,
         color_function=None,
+        colorscale=colorscale_default,
         custom_tooltips=None,
         custom_meta=None,
         path_html="mapper_visualization_output.html",
@@ -637,11 +638,14 @@ class KeplerMapper(object):
         color_function : list or 1d array
             A 1d vector with length equal to number of data points used to build Mapper. Each value should correspond to a value for each data point and color of node is computed as the average value for members in a node.
 
+        colorscale : list
+            Specify the colorscale to use. See visuals.colorscale_default.
+
         path_html : String
             file name for outputing the resulting html.
 
         custom_meta: dict
-            Render (key, value) in the Mapper Summary pane. 
+            Render (key, value) in the Mapper Summary pane.
 
         custom_tooltip: list or array like
             Value to display for each entry in the node. The cluster data pane will display entry for all values in the node. Default is index of data.
@@ -685,7 +689,7 @@ class KeplerMapper(object):
 
         >>> # Customizing the output text
         >>> html = mapper.visualize(
-        >>>     graph, 
+        >>>     graph,
         >>>     path_html="kepler-mapper-output.html",
         >>>     title="Fashion MNIST with UMAP",
         >>>     custom_meta={"Description":"A short description.",
@@ -708,7 +712,7 @@ class KeplerMapper(object):
         >>> # Customizing the tooltips with binary target variables
         >>> X, y = split_data(df)
         >>> html = mapper.visualize(
-        >>>     graph, 
+        >>>     graph,
         >>>     path_html="kepler-mapper-output.html",
         >>>     title="Fashion MNIST with UMAP",
         >>>     custom_tooltips=y
@@ -716,7 +720,7 @@ class KeplerMapper(object):
 
         >>> # Customizing the tooltips with html-strings: locally stored images of an image dataset
         >>> html = mapper.visualize(
-        >>>     graph, 
+        >>>     graph,
         >>>     path_html="kepler-mapper-output.html",
         >>>     title="Fashion MNIST with UMAP",
         >>>     custom_tooltips=np.array(
@@ -750,6 +754,7 @@ class KeplerMapper(object):
         mapper_data = format_mapper_data(
             graph,
             color_function,
+            colorscale,
             X,
             X_names,
             lens,
@@ -758,8 +763,6 @@ class KeplerMapper(object):
             env,
             nbins,
         )
-
-        colorscale = colorscale_default
 
         histogram = graph_data_distribution(graph, color_function, colorscale)
 

--- a/kmapper/kmapper.py
+++ b/kmapper/kmapper.py
@@ -754,7 +754,6 @@ class KeplerMapper(object):
         mapper_data = format_mapper_data(
             graph,
             color_function,
-            colorscale,
             X,
             X_names,
             lens,
@@ -762,6 +761,7 @@ class KeplerMapper(object):
             custom_tooltips,
             env,
             nbins,
+            colorscale=colorscale,
         )
 
         histogram = graph_data_distribution(graph, color_function, colorscale)

--- a/kmapper/kmapper.py
+++ b/kmapper/kmapper.py
@@ -615,7 +615,7 @@ class KeplerMapper(object):
         self,
         graph,
         color_function=None,
-        colorscale=colorscale_default,
+        colorscale=None,
         custom_tooltips=None,
         custom_meta=None,
         path_html="mapper_visualization_output.html",
@@ -729,6 +729,8 @@ class KeplerMapper(object):
         >>> )
 
         """
+        if colorscale is None:
+            colorscale = colorscale_default
 
         # TODO:
         #   - Make color functions more intuitive. How do they even work?

--- a/kmapper/visuals.py
+++ b/kmapper/visuals.py
@@ -104,6 +104,12 @@ def colorscale_from_matplotlib_cmap(cmap, ii_off=0, ff_off=0, nbins=10):
     >>> colorscale = colorscale_from_matplotlib_cmap(plt.cm.cool, ff_off=255//10)
 
     """
+    if cmap.N != 256:
+        raise ValueError("Not implemented for colormaps with cmap.N != 256")
+
+    if ii_off + ff_off > 256:
+        raise ValueError("ii_off + ff_off must be less than 256")
+
     ii = 0 + ii_off
     ff = cmap.N - ff_off
     sk = (cmap.N - ii_off - ff_off) // (nbins + 1)
@@ -115,6 +121,9 @@ def colorscale_from_matplotlib_cmap(cmap, ii_off=0, ff_off=0, nbins=10):
             int(255 * el[0]), int(255 * el[1]), int(255 * el[2])
         ) for el in cmap_list
     ]
+    if len(cmap_list) != nbins + 1:
+        raise ValueError("Failed to build correct size colorscale")
+
     return list(zip(np.arange(nbins + 1) / nbins, rgb_strings))
 
 

--- a/kmapper/visuals.py
+++ b/kmapper/visuals.py
@@ -165,7 +165,7 @@ def format_meta(graph, custom_meta=None, color_function_name=None):
 
 
 def format_mapper_data(
-    graph, color_function, X, X_names, lens, lens_names, custom_tooltips, env, nbins=10
+    graph, color_function, colorscale, X, X_names, lens, lens_names, custom_tooltips, env, nbins=10
 ):
     # import pdb; pdb.set_trace()
     json_dict = {"nodes": [], "links": []}
@@ -184,6 +184,7 @@ def format_mapper_data(
             lens,
             lens_names,
             color_function,
+            colorscale,
             node_id,
             nbins,
         )
@@ -210,12 +211,9 @@ def format_mapper_data(
     return json_dict
 
 
-def build_histogram(data, colorscale=None, nbins=10):
+def build_histogram(data, colorscale=colorscale_default, nbins=10):
     """ Build histogram of data based on values of color_function
     """
-
-    if colorscale is None:
-        colorscale = colorscale_default
 
     # TODO: we should weave this method of handling colors into the normal build_histogram and combine both functions
     colorscale = _colors_to_rgb(colorscale)
@@ -377,6 +375,7 @@ def _format_tooltip(
     lens,
     lens_names,
     color_function,
+    colorscale,
     node_ID,
     nbins,
 ):
@@ -389,8 +388,6 @@ def _format_tooltip(
 
     # list will render better than numpy arrays
     custom_tooltips = list(custom_tooltips)
-
-    colorscale = colorscale_default
 
     projection_stats, cluster_stats, histogram = _tooltip_components(
         member_ids,

--- a/kmapper/visuals.py
+++ b/kmapper/visuals.py
@@ -59,6 +59,14 @@ palette = [
 
 
 def colorscale_from_matplotlib_cmap(cmap, ii_off=0, ff_off=0, nbins=10):
+    """Create a colorscale from a matplotlib colormap.
+    see https://matplotlib.org/tutorials/colors/colormaps.html
+
+    Example:
+      import matplotlib.pyplot as plt
+      cmap = plt.cm.cool
+      colorscale = colorscale_from_matplotlib_cmap(plt.cm.cool)
+    """
     ii = 0 + ii_off
     ff = cmap.N - ff_off
     sk = (cmap.N - ii_off - ff_off) // (nbins + 1)

--- a/kmapper/visuals.py
+++ b/kmapper/visuals.py
@@ -58,6 +58,21 @@ palette = [
 ]
 
 
+def colorscale_from_matplotlib_cmap(cmap, ii_off=0, ff_off=0, nbins=10):
+    ii = 0 + ii_off
+    ff = cmap.N - ff_off
+    sk = (cmap.N - ii_off - ff_off) // (nbins + 1)
+    cmap_list = [
+        cmap(el) for el in np.arange(cmap.N)[ii:ff:sk]
+    ]
+    rgb_strings = [
+        "rgb({}, {}, {})".format(
+            int(255 * el[0]), int(255 * el[1]), int(255 * el[2])
+        ) for el in cmap_list
+    ]
+    return list(zip(np.arange(nbins + 1) / nbins, rgb_strings))
+
+
 def _colors_to_rgb(colorscale):
     """ Ensure that the color scale is formatted in rgb strings.
         If the colorscale is a hex string, then convert to rgb.

--- a/kmapper/visuals.py
+++ b/kmapper/visuals.py
@@ -165,7 +165,7 @@ def format_meta(graph, custom_meta=None, color_function_name=None):
 
 
 def format_mapper_data(
-    graph, color_function, colorscale, X, X_names, lens, lens_names, custom_tooltips, env, nbins=10
+        graph, color_function, X, X_names, lens, lens_names, custom_tooltips, env, nbins=10, colorscale=colorscale_default,
 ):
     # import pdb; pdb.set_trace()
     json_dict = {"nodes": [], "links": []}

--- a/kmapper/visuals.py
+++ b/kmapper/visuals.py
@@ -60,11 +60,49 @@ palette = [
 
 def colorscale_from_matplotlib_cmap(cmap, ii_off=0, ff_off=0, nbins=10):
     """Create a colorscale from a matplotlib colormap.
-    see https://matplotlib.org/tutorials/colors/colormaps.html
 
-    Example:
-      import matplotlib.pyplot as plt
-      colorscale = colorscale_from_matplotlib_cmap(plt.cm.cool)
+    See https://matplotlib.org/tutorials/colors/colormaps.html
+    for more details about matplotlib colormaps.
+
+    Parameters
+    ----------
+
+    cmap : matplotlib.colors.LinearSegmentedColormap
+        A matplotlib colormap
+
+    ii_off : int
+        The starting index offset to use when sampling the matplotlib
+        colormap. Must be in the range 0-255.
+
+    ff_off : int
+        The ending index offset to use when sampling the matplotlib
+        colormap. Must be in the range 0-255.
+
+    nbins : int
+        Number of bins (i.e. samples of the colormap) to take when
+        constructing the colorscale.
+
+    Returns
+    -------
+
+    colorscale
+        A colorscale
+
+    Examples
+    --------
+
+    >>> import matplotlib.pyplot as plt
+    >>> # use a non-truncated colormap
+    >>> colorscale = colorscale_from_matplotlib_cmap(plt.cm.cool)
+
+    >>> import matplotlib.pyplot as plt
+    >>> # skip the first 10% of the matplotlib colormap
+    >>> colorscale = colorscale_from_matplotlib_cmap(plt.cm.cool, ii_off=255//10)
+
+    >>> import matplotlib.pyplot as plt
+    >>> # skip the last 10% of the matplotlib colormap
+    >>> colorscale = colorscale_from_matplotlib_cmap(plt.cm.cool, ff_off=255//10)
+
     """
     ii = 0 + ii_off
     ff = cmap.N - ff_off

--- a/kmapper/visuals.py
+++ b/kmapper/visuals.py
@@ -64,7 +64,6 @@ def colorscale_from_matplotlib_cmap(cmap, ii_off=0, ff_off=0, nbins=10):
 
     Example:
       import matplotlib.pyplot as plt
-      cmap = plt.cm.cool
       colorscale = colorscale_from_matplotlib_cmap(plt.cm.cool)
     """
     ii = 0 + ii_off

--- a/kmapper/visuals.py
+++ b/kmapper/visuals.py
@@ -165,8 +165,11 @@ def format_meta(graph, custom_meta=None, color_function_name=None):
 
 
 def format_mapper_data(
-        graph, color_function, X, X_names, lens, lens_names, custom_tooltips, env, nbins=10, colorscale=colorscale_default,
+        graph, color_function, X, X_names, lens, lens_names, custom_tooltips, env, nbins=10, colorscale=None,
 ):
+    if colorscale is None:
+        colorscale = colorscale_default
+
     # import pdb; pdb.set_trace()
     json_dict = {"nodes": [], "links": []}
     node_id_to_num = {}
@@ -211,9 +214,11 @@ def format_mapper_data(
     return json_dict
 
 
-def build_histogram(data, colorscale=colorscale_default, nbins=10):
+def build_histogram(data, colorscale=None, nbins=10):
     """ Build histogram of data based on values of color_function
     """
+    if colorscale is None:
+        colorscale = colorscale_default
 
     # TODO: we should weave this method of handling colors into the normal build_histogram and combine both functions
     colorscale = _colors_to_rgb(colorscale)


### PR DESCRIPTION
Allows the user to pass in a custom colorscale. 

Sorry for the whitespace change noise. I don't have strong opinions about this stuff, but my editor has its settings. I can submit a different PR w/o these whitespace changes if it helps. I'll put comments on the changes relevant to colorscale.

In some places I used `colorscale=colorscale_default` in function signatures instead of None. If the mutable default is a problem I can either change back to None and put the `if colorscale is None` logic in each function OR write a function in visuals called `_return_default_colorscale` and call that function as the kwarg default value ... so  `colorscale=_return_default_colorscale()` instead of `colorscale=None`.
