### PR TITLE
Fix search mode and size

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,8 +12,8 @@
 
 - The AND and OR searchbar queries no longer multiplies the base size of a node by the ratio of how many of its items match. Rather,
   the base size of the node is simply multiplied by how many of its items match the query. With this change, the size of a node
-  during an AND or OR search query again directly reflects the number of items within the node.
-- The default search mode is now AND -- because that's the expected behavior, because that's how the google works
+  during an AND or OR search query again directly reflects the number of items within the node. (#227)
+- The default search mode is now AND -- because that's the expected behavior, because that's how the google works (#227)
 
 
 ## 2.0.0

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,12 @@
 - `plotlyviz.scomplex_to_graph` no longer casts `color_values` to a 2d array, and `visuals._tooltip_components` now generates
   either 1d or 2d `member_histogram` depending on dimensionality of `color_values` (#225)
 
+### Fixed/Changed
+
+- The AND and OR searchbar queries no longer multiplies the base size of a node by the ratio of how many of its items match. Rather,
+  the base size of the node is simply multiplied by how many of its items match the query. With this change, the size of a node
+  during an AND or OR search query again directly reflects the number of items within the node.
+
 ## 2.0.0
 
 ### Visualization

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,8 @@
 - The AND and OR searchbar queries no longer multiplies the base size of a node by the ratio of how many of its items match. Rather,
   the base size of the node is simply multiplied by how many of its items match the query. With this change, the size of a node
   during an AND or OR search query again directly reflects the number of items within the node.
+- The default search mode is now AND -- because that's the expected behavior, because that's how the google works
+
 
 ## 2.0.0
 

--- a/kmapper/kmapper.py
+++ b/kmapper/kmapper.py
@@ -719,11 +719,11 @@ class KeplerMapper(object):
             methods, all against lowercased tooltips.
 
             * AND: the search query is split by whitespace. A data point's custom tooltip must
-              match _each_ of the query terms in order to match overall. The size of a node
-              is drawn as a ratio of how many of its datapoints match.
+              match _each_ of the query terms in order to match overall. The base size of a node
+              is multiplied by the number of datapoints matching the searchquery.
             * OR: the search query is split by whitespace. A data point's custom tooltip must
-              match _any_ of the query terms in order to match overall. The size of a node
-              is drawn as a ratio of how many of its datapoints match.
+              match _any_ of the query terms in order to match overall. The base size of a node
+              is multiplied by the number of datapoints matching the searchquery.
             * EXACT: A data point's custom tooltip must exactly match the query. Any nodes
               with a matching datapoint are set to glow.
 

--- a/kmapper/static/kmapper.js
+++ b/kmapper/static/kmapper.js
@@ -576,9 +576,14 @@ d3.select('#searchbar')
           let node_ratio_fn = (d, i) => {
             matches = d.tooltip.custom_tooltips_lowercase.map(map_fn)
             let how_many = matches.filter(x=>x).length;
+
+            // Future optional feature -- size relative to ratio _within-node_
             let out_of = d.tooltip.cluster_stats.size;
             let ratio = how_many / out_of;
-            d.size_modifier = ratio * 100;
+
+            // Node sizes will be overall number of items in the node
+            // number of matching
+            d.size_modifier = how_many;
           }
 
           let map_fn;

--- a/kmapper/templates/toolbar.html
+++ b/kmapper/templates/toolbar.html
@@ -52,10 +52,10 @@
         <button class='btn' type='submit'>Search</button>
         <div class="inline-block">
           <div class="inline-block">
-            <input type="radio" name="search_mode" id='search-mode-or'    value="or" checked><label for="search-mode-or">OR</label>
+            <input type="radio" name="search_mode" id='search-mode-and'   value="and" checked><label for="search-mode-and">AND</label>
           </div>
           <div class="inline-block">
-            <input type="radio" name="search_mode" id='search-mode-and'   value="and"><label for="search-mode-and">AND</label>
+            <input type="radio" name="search_mode" id='search-mode-or'    value="or" ><label for="search-mode-or">OR</label>
           </div>
           <div class="inline-block">
             <input type="radio" name="search_mode" id='search-mode-exact' value="exact"><label for="search-mode-exact">Exact</label>


### PR DESCRIPTION
- The AND and OR searchbar queries no longer multiplies the base size of a node by the ratio of how many of its items match. Rather, the base size of the node is simply multiplied by how many of its items match the query. With this change, the size of a node during an AND or OR search query again directly reflects the number of items within the node.
- The default search mode is now AND (used to be OR) -- because AND is the user-expected behavior, because that's how the google works