### PR TITLE
Passing in custom_tooltips and index the list for each nodes

### DIFF
--- a/kmapper/plotlyviz.py
+++ b/kmapper/plotlyviz.py
@@ -239,6 +239,16 @@ def scomplex_to_graph(
         node_color = _node_color_function(member_ids, color_values, node_color_function)
         if isinstance(node_color, np.ndarray):
             node_color = node_color.tolist()
+        
+        node_custom_tooltips=None
+        if custom_tooltips is not None:
+            try:
+                # custom_tooltips may not be an np.array 
+                node_custom_tooltips = custom_tooltips[member_ids]
+            except:
+                raise Warning("Failed to index custom_tooltips")
+                node_custom_tooltips = custom_tooltips    
+        
         n = {
             "id": i,
             "name": node_id,
@@ -248,7 +258,7 @@ def scomplex_to_graph(
             "cluster": cluster_stats,
             "distribution": member_histogram,
             "projection": projection_stats,
-            "custom_tooltips": custom_tooltips,
+            "custom_tooltips": node_custom_tooltips,
         }
 
         json_dict["nodes"].append(n)


### PR DESCRIPTION
Set custom_tooltips for each nodes using custom_tooltips arg

Old version code
``` python
kmgraph,  mapper_summary, colorf_distribution = get_mapper_graph(scomplex,
                                                                 color_values,
                                                                 color_function_name='Distance to x-min',
                                                                 colorscale=my_colorscale)

# assign to node['custom_tooltips']  the node label (0 for benign, 1 for malignant)
for node in kmgraph['nodes']:
    node['custom_tooltips'] = y[scomplex['nodes'][node['name']]]
```

New version

``` python
ctooltips=  y

kmgraph,  mapper_summary, colorf_distribution = get_mapper_graph(scomplex,
                                                                 color_values,
                                                                 color_function_name="'Distance to x-min',
                                                                 colorscale=my_colorscale,
                                                                 custom_tooltips=ctooltips
                                                                 )



# assign to node['custom_tooltips']  the node label (0 for benign, 1 for malignant)
# assign to node['custom_tooltips']  the node label (0 for benign, 1 for malignant)
#for node in kmgraph['nodes']:
  #  node['custom_tooltips'] = y[scomplex['nodes'][node['name']]]
```
index the passed in custom_tooltips array for each node otherwise all the node will have the same custom_tooltips array.
