### PR TITLE
add ability to d3 vis to live-update min-intersection requirement

### DIFF
--- a/kmapper/kmapper.py
+++ b/kmapper/kmapper.py
@@ -578,6 +578,7 @@ class KeplerMapper(object):
             "perc_overlap": self.cover.perc_overlap,
             "clusterer": str(clusterer),
             "scaler": str(self.scaler),
+            "nerve_min_intersection": nerve.min_intersection
         }
         graph["meta_nodes"] = meta
 
@@ -639,6 +640,7 @@ class KeplerMapper(object):
         lens_names=None,
         nbins=10,
         include_searchbar=False,
+        include_min_intersection_selector=False
     ):
         """Generate a visualization of the simplicial complex mapper output. Turns the complex dictionary into a HTML/D3.js visualization
 
@@ -728,6 +730,10 @@ class KeplerMapper(object):
               with a matching datapoint are set to glow.
 
             To reset any search-induced visual alterations, submit an empty search query.
+
+        include_min_intersection_selector: bool, default False
+            Whether to include an input to dynamically change the min_intersection
+            for an edge to be drawn.
 
         Returns
         --------
@@ -917,7 +923,7 @@ class KeplerMapper(object):
         )
 
         html = _render_d3_vis(
-            title, mapper_summary, histogram, mapper_data, colorscale, include_searchbar
+            title, mapper_summary, histogram, mapper_data, colorscale, include_searchbar, include_min_intersection_selector
         )
 
         if save_file:

--- a/kmapper/templates/toolbar.html
+++ b/kmapper/templates/toolbar.html
@@ -65,4 +65,15 @@
     </div>
     {% endif %}
 
+    {% if include_min_intersection_selector %}
+    <div id='min_intersction_selector' class="tool_item">
+      <form>
+        <h3>Min Intersection Selector
+        <input type="number" min="1" value="{{ mapper_summary.custom_meta.nerve_min_intersection }}">
+        <button class='btn' type='submit'>Update</button>
+        </h3>
+      </form>
+    </div>
+    {% endif %}
+
 </div>

--- a/kmapper/visuals.py
+++ b/kmapper/visuals.py
@@ -548,7 +548,7 @@ def _format_tooltip(
 
 
 def _render_d3_vis(
-    title, mapper_summary, histogram, mapper_data, colorscale, include_searchbar
+    title, mapper_summary, histogram, mapper_data, colorscale, include_searchbar, include_min_intersection_selector
 ):
     # Find the module absolute path and locate templates
     module_root = os.path.join(os.path.dirname(__file__), "templates")
@@ -587,6 +587,7 @@ def _render_d3_vis(
         js_text=js_text,
         css_text=css_text,
         include_searchbar=include_searchbar,
+        include_min_intersection_selector=include_min_intersection_selector
     )
 
     return html

--- a/test/test_visuals.py
+++ b/test/test_visuals.py
@@ -393,6 +393,26 @@ class TestVisualHelpers:
             include_searchbar=True,
         )
 
+    def test_visualize_min_intersection_selector(self):
+        """ convenience test for generating a vis with a min_intersection_selector
+        (and also with multiple color_values _and_ multiple node_color_values)"""
+        mapper = KeplerMapper()
+        data, labels = make_circles(1000, random_state=0)
+        lens = mapper.fit_transform(data, projection=[0])
+        graph = mapper.map(lens, data)
+        color_values = lens[:, 0]
+
+        cv1 = np.array(lens)
+        cv2 = np.flip(cv1)
+        cv = np.column_stack([cv1, cv2])
+        mapper.visualize(
+            graph,
+            color_values=cv,
+            node_color_function=["mean", "std"],
+            color_function_name=["hotdog", "hotdiggitydog"],
+            include_min_intersection_selector=True,
+        )
+
     def test_visualize_graph_with_cluster_stats_above_below(self):
         mapper = KeplerMapper()
         X = np.ones((1000, 3))


### PR DESCRIPTION
if `include_min_intersection_selector=True` is passed to 
mapper.visualize,
then a number input is included at the top of the d3 vis which permits
changing the min_intersection req for edges (links) to be drawn.

Currently does not get saved in the downloadable config file.