### PR TITLE
Updated deprecated numpy function in visuals.py

### DIFF
--- a/kmapper/visuals.py
+++ b/kmapper/visuals.py
@@ -572,7 +572,7 @@ def _render_d3_vis(
     def my_dumper(obj, **kwargs):
         def np_encoder(object, **kwargs):
             if isinstance(object, np.generic):
-                return np.asscalar(object)
+                return object.item()
 
         return json.dumps(obj, default=np_encoder, **kwargs)
 


### PR DESCRIPTION
np.asscalar() is deprecated as of numpy version 1.16. I updated this code to use np.ndarray.item() instead of np.asscalar()