### PR TITLE
changed np.asscalar to object.item fixes #252

### DIFF
--- a/kmapper/visuals.py
+++ b/kmapper/visuals.py
@@ -572,7 +572,8 @@ def _render_d3_vis(
     def my_dumper(obj, **kwargs):
         def np_encoder(object, **kwargs):
             if isinstance(object, np.generic):
-                return np.asscalar(object)
+                #return np.asscalar(object) <-- np.asscalar is deprecated in later versions of numpy
+                return object.item()
 
         return json.dumps(obj, default=np_encoder, **kwargs)
 


### PR DESCRIPTION
fixed the issue with np.asscalar that seems to be deprecated in numpy future versions. "AttributeError: module 'numpy' has no attribute 'asscalar'" 