### PR TITLE
Switch python-igraph to igraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@
 
 > Nature uses as little as possible of anything. - Johannes Kepler
 
-This is a Python implementation of the TDA Mapper algorithm  for visualization of high-dimensional data. For complete documentation, see [https://kepler-mapper.scikit-tda.org](https://kepler-mapper.scikit-tda.org).
+This is a Python implementation of the TDA Mapper algorithm for visualization of high-dimensional data. For complete documentation, see [https://kepler-mapper.scikit-tda.org](https://kepler-mapper.scikit-tda.org).
 
 KeplerMapper employs approaches based on the Mapper algorithm (Singh et al.) as first described in the paper "Topological Methods for the Analysis of High Dimensional Data Sets and 3D Object Recognition".
 
 KeplerMapper can make use of Scikit-Learn API compatible cluster and scaling algorithms.
-
 
 ## Install
 
@@ -22,21 +21,20 @@ KeplerMapper can make use of Scikit-Learn API compatible cluster and scaling alg
 
 KeplerMapper requires:
 
-  - Python (>= 3.6)
-  - NumPy
-  - Scikit-learn
+- Python (>= 3.6)
+- NumPy
+- Scikit-learn
 
 Using the plotly visualizations requires a few extra libraries:
 
-  - Python-Igraph
-  - Plotly
-  - Ipywidgets
+- igraph
+- Plotly
+- Ipywidgets
 
 Additionally, running some of the examples requires:
 
-  - matplotlib
-  - umap-learn
-
+- matplotlib
+- umap-learn
 
 ### Installation
 
@@ -47,6 +45,7 @@ pip install kmapper
 ```
 
 To install from source:
+
 ```
 git clone https://github.com/MLWave/kepler-mapper
 cd kepler-mapper
@@ -58,6 +57,7 @@ pip install -e .
 KeplerMapper adopts the scikit-learn API as much as possible, so it should feel very familiar to anyone who has used these libraries.
 
 ### Python code
+
 ```python
 # Import the class
 import kmapper as km

--- a/kmapper/plotlyviz.py
+++ b/kmapper/plotlyviz.py
@@ -24,9 +24,9 @@ try:
     import plotly.io as pio
 except ImportError:
     print(
-        """To use the plotly visualization tools, you must have the packages python-igraph, plotly, and ipywidgets installed in your environment."""
+        """To use the plotly visualization tools, you must have the packages igraph, plotly, and ipywidgets installed in your environment."""
         """ It looks like at least one of these is missing.  Please install again with"""
-        """\n\n\t`pip install python-igraph plotly ipywidgets`\n\nand try again"""
+        """\n\n\t`pip install igraph plotly ipywidgets`\n\nand try again"""
     )
     raise
 
@@ -226,7 +226,6 @@ def scomplex_to_graph(
     colorscale,
     node_color_function="mean",
 ):
-
     color_values = np.array(color_values)
 
     json_dict = {"nodes": [], "links": []}
@@ -712,7 +711,6 @@ def _get_plotly_data(E, coords):
 
 
 def _text_mapper_summary(mapper_summary):
-
     d = mapper_summary["custom_meta"]
     text = "<br><b>Projection: </b>" + d["projection"]
     text += (

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
             "pytest",  # ~=6.2.5",
             "networkx",  # ~=2.5.1",
             "matplotlib",  # ~=3.3.4",
-            "python-igraph",  # ~=0.9.6",
+            "igraph",
             "plotly",  # ~=5.3.1",
             "ipywidgets",  # ~=7.6.5",
         ],
@@ -45,7 +45,7 @@ setup(
             # for building docs for plotlyviz stuff
             "networkx",  # ~=2.5.1",
             "matplotlib",  # ~=3.3.4",
-            "python-igraph",  # ~=0.9.6",
+            "igraph",
             "plotly",  # ~=5.3.1",
             "ipykernel",
             "ipywidgets",  # ~=7.6.5",


### PR DESCRIPTION
As raised in #249, `python-igraph` is deprecated and `igraph` is the drop-in replacement. This PR replaces `python-igraph` with `igraph`.

Closes #249 